### PR TITLE
Reduce memory usage in FileCache.Find

### DIFF
--- a/BruTile.Desktop/Cache/FileCache.cs
+++ b/BruTile.Desktop/Cache/FileCache.cs
@@ -60,10 +60,7 @@ namespace BruTile.Cache
             lock (_syncRoot)
             {
                 if (!Exists(index)) return null; // to indicate not found
-                using (var fileStream = new FileStream(GetFileName(index), FileMode.Open, FileAccess.Read))
-                {
-                    return Utilities.ReadFully(fileStream);
-                }
+                return File.ReadAllBytes(GetFileName(index));
             }
         }
 


### PR DESCRIPTION
Change from Utilities.ReadFully(Stream) to File.ReadAllBytes(string) so
that the memory isn't allocated multiple times.
