### PR TITLE
Fix crash if authority is not uppercase in Wmts description

### DIFF
--- a/BruTile/Wmts/CrsUnitOfMeasureRegistry.cs
+++ b/BruTile/Wmts/CrsUnitOfMeasureRegistry.cs
@@ -467,7 +467,7 @@ namespace BruTile.Wmts
         {
             get
             {
-                switch (identifier.Authority)
+                switch (identifier.Authority.ToUpper())
                 {
                     case "OGC":
                         if (identifier.Equals(WellKnownScaleSets.CRS84))


### PR DESCRIPTION
Hi,
I'm new to develop on Github. So I'm not completely aware of the procedures here.
But any ways here two little changes which I had to do to get BruTile working with our Wmts.