### PR TITLE
Option to disable the tile range optimization

### DIFF
--- a/BruTile.MbTiles.Pcl/MbTilesTileSource.cs
+++ b/BruTile.MbTiles.Pcl/MbTilesTileSource.cs
@@ -29,7 +29,7 @@ namespace BruTile
             _connectionString = connectionString;
 			if (tileRangeOptimization || schema == null)
 			{
-				var connection = new SQLiteConnectionWithLock(connectionString, SQLiteOpenFlags.ReadOnly);
+				using (var connection = new SQLiteConnectionWithLock(connectionString, SQLiteOpenFlags.ReadOnly))
 				using (connection.Lock())
 				{
 					Type = type == MbTilesType.None ? ReadType(connection) : type;
@@ -113,7 +113,7 @@ namespace BruTile
             if (IsTileIndexValid(index))
             {
                 byte[] result;
-                var cn = new SQLiteConnectionWithLock(_connectionString, SQLiteOpenFlags.ReadOnly);
+				using (var cn = new SQLiteConnectionWithLock(_connectionString, SQLiteOpenFlags.ReadOnly))
                 using (cn.Lock())
                 {
                     const string sql =

--- a/BruTile.MbTiles.Pcl/MbTilesTileSource.cs
+++ b/BruTile.MbTiles.Pcl/MbTilesTileSource.cs
@@ -47,7 +47,7 @@ namespace BruTile
 			}
         }
 
-        private ITileSchema ReadSchemaFromDatabase(SQLiteConnectionWithLock connection)
+        private static ITileSchema ReadSchemaFromDatabase(SQLiteConnectionWithLock connection)
         {
             var format = ReadFormat(connection);
             var extent = ReadExtent(connection);

--- a/BruTile/BruTile.csproj
+++ b/BruTile/BruTile.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>BruTile</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <Net40>NET40</Net40>
-    <!--<ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>-->
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <PropertyGroup>
     <Portability Condition="'$(Configuration)' == 'Debug Portable'">PCL</Portability>


### PR DESCRIPTION
I deleted my fork and made a new, cleaned up fork so I can send you a sensible PR.

1) The tile range optimization can be disabled with an _optional parameter_. If it is disabled, _and_ a schema is provided, than the schema will not be read from the database at all.

2) Using blocks are used around SQLiteConnection object. They are _disposable_ and thus ought to be disposed.

3) I removed the comment tags around the ProjectGuids tag because this renders the project unopenable on Visual Studio for Mac / Xamarin.