### PR TITLE
 Added some stuff for vector tiles in MBTilesTileSource 

### DIFF
--- a/BruTile.MbTiles/MbTilesFormat.cs
+++ b/BruTile.MbTiles/MbTilesFormat.cs
@@ -22,7 +22,11 @@ namespace BruTile.MbTiles
         /// <summary>
         /// Joint Photographic Experts Group (JPEG)
         /// </summary>
-        Jpeg = Jpg
+        Jpeg = Jpg,
 
+        /// <summary>
+        /// Protobuf vector format
+        /// </summary>
+        Pbf
     }
 }

--- a/BruTile.MbTiles/MbTilesFormat.cs
+++ b/BruTile.MbTiles/MbTilesFormat.cs
@@ -25,6 +25,11 @@ namespace BruTile.MbTiles
         Jpeg = Jpg,
 
         /// <summary>
+        /// Webp format
+        /// </summary>
+        Webp,
+
+        /// <summary>
         /// Protobuf vector format
         /// </summary>
         Pbf


### PR DESCRIPTION
Added format Pbf and Webp to possible formats for MBTiles.
Added some properties in MBTilesTileSource, most for updates from MBTiles format version 1.3.
Added property Compression, because it comes with version 1.4.

What missing up to now is the center from MBTiles file. Couldn't do this, because I found no point or coordinate object in BruTile. Perhaps it could be done by CenterX and CenterY?