### PR TITLE
Change MatrixHeight and MatrixWidth to long to cater for zoom level 30

### DIFF
--- a/BruTile/ITileSchema.cs
+++ b/BruTile/ITileSchema.cs
@@ -57,14 +57,14 @@ namespace BruTile
         /// </summary>
         /// <param name="levelId">The zoom level's id</param>
         /// <returns>The matrix width</returns>
-        int GetMatrixWidth(string levelId);
+        long GetMatrixWidth(string levelId);
 
         /// <summary>
         /// Function to get the matrix height (aka number of rows) of the schema for a given zoom level.
         /// </summary>
         /// <param name="levelId">The zoom level's id</param>
         /// <returns>The matrix height</returns>
-        int GetMatrixHeight(string levelId);
+        long GetMatrixHeight(string levelId);
 
         /// <summary>
         /// Gets a value indicating the resolutions defined in this schema

--- a/BruTile/Predefined/SphericalMercatorWorldSchema.cs
+++ b/BruTile/Predefined/SphericalMercatorWorldSchema.cs
@@ -23,7 +23,7 @@ namespace BruTile.Predefined
             foreach (var unitsPerPixel in unitsPerPixelArray)
             {
                 var levelId = count.ToString(CultureInfo.InvariantCulture);
-                var ms = (int) Math.Pow(count, 2) / 2;
+                var ms = (long) Math.Pow(count, 2) / 2;
 
                 // Most of the parameters to the Resolutions constructor are not used for TileSchema.
                 // This is confusing and should be changed.

--- a/BruTile/Resolution.cs
+++ b/BruTile/Resolution.cs
@@ -11,13 +11,13 @@ namespace BruTile
         private readonly double _left;
         private readonly int _tileWidth;
         private readonly int _tileHeight;
-        private readonly int _matrixWidth;
-        private readonly int _matrixHeight;
+        private readonly long _matrixWidth;
+        private readonly long _matrixHeight;
 
         public Resolution(string id, double unitsPerPixel, 
             int tileWidth = 256, int tileHeight = 256,
             double left = 0, double top = 0,
-            int matrixWidth = 0, int matrixHeight = 0,
+            long matrixWidth = 0, long matrixHeight = 0,
             double scaledenominator = 0)
         {
             _id = id;
@@ -66,12 +66,12 @@ namespace BruTile
             get { return _tileHeight; }
         }
 
-        public int MatrixWidth
+        public long MatrixWidth
         {
             get { return _matrixWidth; }
         }
 
-        public int MatrixHeight
+        public long MatrixHeight
         {
             get { return _matrixHeight; }
         }

--- a/BruTile/TileSchema.cs
+++ b/BruTile/TileSchema.cs
@@ -76,12 +76,12 @@ namespace BruTile
             return Resolutions[levelId].TileHeight;
         }
 
-        public int GetMatrixWidth(string levelId)
+        public long GetMatrixWidth(string levelId)
         {
             return GetMatrixLastCol(levelId) - GetMatrixFirstCol(levelId) + 1;
         }
 
-        public int GetMatrixHeight(string levelId)
+        public long GetMatrixHeight(string levelId)
         {
             return GetMatrixLastRow(levelId) - GetMatrixFirstRow(levelId) + 1;
         }

--- a/BruTile/Wmsc/WmscRequest.cs
+++ b/BruTile/Wmsc/WmscRequest.cs
@@ -31,7 +31,7 @@ namespace BruTile.Wmsc
             _customParameters = customParameters;
             _layers = layers.ToList();
             _schema = schema;
-            _styles = styles?.ToList();
+            _styles = (styles == null) ? null : styles.ToList();
             _version = version;
         }
 

--- a/BruTile/Wmts/WmtsParser.cs
+++ b/BruTile/Wmts/WmtsParser.cs
@@ -354,8 +354,8 @@ namespace BruTile.Wmts
                     CultureInfo.InvariantCulture), 
                     Convert.ToDouble(coords[ordinateOrder[1]], 
                     CultureInfo.InvariantCulture),
-                    (int)tileMatrix.MatrixWidth,
-                    (int)tileMatrix.MatrixHeight,
+                    (long)tileMatrix.MatrixWidth,
+                    (long)tileMatrix.MatrixHeight,
                     tileMatrix.ScaleDenominator));
           }
     }

--- a/BruTile/Wmts/WmtsTileSchema.cs
+++ b/BruTile/Wmts/WmtsTileSchema.cs
@@ -153,12 +153,12 @@ namespace BruTile.Wmts
             return Resolutions[levelId].Top;
         }
 
-        public int GetMatrixWidth(string levelId)
+        public long GetMatrixWidth(string levelId)
         {
             return Resolutions[levelId].MatrixWidth;
         }
 
-        public int GetMatrixHeight(string levelId)
+        public long GetMatrixHeight(string levelId)
         {
             return Resolutions[levelId].MatrixHeight;
         }


### PR DESCRIPTION
We've come accross a WMTS provider that has a tile matrix with 30 zoom levels, causing the matrix width to overflow, this PR is to change this from an int to a long. Attached is the WMTS GetCpapabilities demonstrating this issue.
[wmts_getcapabilities.zip](https://github.com/BruTile/BruTile/files/3484929/wmts_getcapabilities.zip)

