### PR TITLE
Added a Zoom property (Level as integer) to TileIndex

### DIFF
--- a/BruTile/TileIndex.cs
+++ b/BruTile/TileIndex.cs
@@ -8,13 +8,25 @@ namespace BruTile
     {
         public int Col { get; }
         public int Row { get; }
-        public string Level { get; }  // Note: TileIndex is a struct but Level is a class which needs GC. It would be nice if we could avoid GC.
+        public int Zoom { get; private set; }
+        public string Level     // Note: TileIndex is a struct but Level is a class which needs GC. It would be nice if we could avoid GC.
+        {
+            get => Zoom.ToString();
+            set
+            {
+                Zoom = (int)float.Parse(value);
+            }
+        }
 
-        public TileIndex(int col, int row, string level)
+        public TileIndex(int col, int row, string level) : this (col, row, (int)float.Parse(level))
+        { 
+        }
+
+        public TileIndex(int col, int row, int zoom)
         {
             Col = col;
             Row = row;
-            Level = level;
+            Zoom = zoom;
         }
 
         public int CompareTo(object obj)
@@ -32,7 +44,9 @@ namespace BruTile
             if (Col > index.Col) return 1;
             if (Row < index.Row) return -1;
             if (Row > index.Row) return 1;
-            return String.Compare(Level, index.Level, StringComparison.Ordinal);
+            if (Zoom < index.Zoom) return -1;
+            if (Zoom > index.Zoom) return 1;
+            return 0;
         }
 
         public override bool Equals(object obj)
@@ -45,12 +59,12 @@ namespace BruTile
 
         public bool Equals(TileIndex index)
         {
-            return Col == index.Col && Row == index.Row && Level == index.Level;
+            return Col == index.Col && Row == index.Row && Zoom == index.Zoom;
         }
 
         public override int GetHashCode()
         {
-            return Col ^ Row ^ ((Level == null) ? 0 : Level.GetHashCode());
+            return Col ^ Row ^ Zoom;
         }
 
         public static bool operator ==(TileIndex key1, TileIndex key2)


### PR DESCRIPTION
The level is a property of TileIndex, that is often used for calculations, but is saved in BruTile as string (acording to WMTS?). This PR tries to circumvent this problem. Level is now only a property, which is created on the fly, while the zoom level is stored in inetger Zoom. So it is possible to use it for any calculations. Nothing changes in the API for TileIndex.

With this, the comment in TileIndex is fullfilled too. Now TileIndex is a structure with no classes. There are only integers.