### PR TITLE
Add BKG TopPlus maps to KnownTileSources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings 
+# TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj
@@ -185,3 +185,6 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 /.vs
+
+# Mac OS
+.DS_Store

--- a/BruTile/Predefined/KnownTileSources.cs
+++ b/BruTile/Predefined/KnownTileSources.cs
@@ -30,13 +30,17 @@ namespace BruTile.Predefined
         EsriWorldReferenceOverlay,
         EsriWorldTransportation,
         EsriWorldBoundariesAndPlaces,
-        EsriWorldDarkGrayBase
+        EsriWorldDarkGrayBase,
+        BKGTopPlusColor,
+        BKGTopPlusGrey
     }
 
     public static class KnownTileSources
     {
         private static readonly Attribution OpenStreetMapAttribution = new Attribution(
             "© OpenStreetMap contributors", "https://www.openstreetmap.org/copyright");
+        private static readonly Attribution BKGAttribution = new Attribution("© Bundesamt für Kartographie und Geodäsie",
+                         "https://sg.geodatenzentrum.de/web_public/Datenquellen_TopPlus_Open.pdf");
 
         /// <summary>
         /// Static factory method for known tile services
@@ -157,6 +161,16 @@ namespace BruTile.Predefined
                     return new HttpTileSource(new GlobalSphericalMercator(0, 16),
                         "https://server.arcgisonline.com/arcgis/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}",
                         name: source.ToString(), persistentCache: persistentCache, tileFetcher: tileFetcher, userAgent: userAgent);
+                case KnownTileSource.BKGTopPlusColor:
+                    return new HttpTileSource(new GlobalSphericalMercator(),
+                        "https://sg.geodatenzentrum.de/wmts_topplus_open/tile/1.0.0/web/default/WEBMERCATOR/{z}/{y}/{x}.png",
+                        name: source.ToString(), persistentCache: persistentCache, tileFetcher: tileFetcher,
+                        attribution: BKGAttribution, userAgent: userAgent);
+                case KnownTileSource.BKGTopPlusGrey:
+                    return new HttpTileSource(new GlobalSphericalMercator(),
+                        "https://sg.geodatenzentrum.de/wmts_topplus_open/tile/1.0.0/web_grau/default/WEBMERCATOR/{z}/{y}/{x}.png",
+                        name: source.ToString(), persistentCache: persistentCache, tileFetcher: tileFetcher,
+                        attribution: BKGAttribution, userAgent: userAgent);
                 default:
                     throw new NotSupportedException("KnownTileSource not known");
             }


### PR DESCRIPTION
This PR adds the openly available topographical maps ("TopPlusOpen") of the German BKG ("Bundesamt für Kartographie und Geodäsie" = "Federal agency of cartography and geodesy") to BruTile's KnownTileSources.

There are two flavors, colored and greyscale. The map provides worldwide coverage, but the available level of resolution differs: Germany is available in high resolution, Europe in medium resolution and the rest of the world in low resolution. The implementation includes the necessary copyright attribution.

For further information about the BKG TopPlus maps, see https://gdz.bkg.bund.de/index.php/default/webdienste/topplus-produkte/wmts-topplusopen-wmts-topplus-open.html