### PR TITLE
Fixed Viewport CenterX and CenterY properties issue

### DIFF
--- a/Samples/BruTile.Samples.Common/Viewport.cs
+++ b/Samples/BruTile.Samples.Common/Viewport.cs
@@ -56,8 +56,8 @@ namespace BruTile.Samples.Common
             get { return _centerX; }
             set
             {
-                UpdateExtent();
                 _centerX = value;
+                UpdateExtent();
             }
         }
 
@@ -66,8 +66,8 @@ namespace BruTile.Samples.Common
             get { return _centerY; }
             set
             {
-                UpdateExtent();
                 _centerY = value;
+              UpdateExtent();
             }
         }
         


### PR DESCRIPTION
I faced a small issue when setting CenterX or CenterY because the update is done before the new value is set (I guess it's a copy/paste issue)