### PR TITLE
Remove net45 and upgrade tests and samples to net48

### DIFF
--- a/BruTile.Desktop.DbCache/BruTile.Desktop.DbCache.csproj
+++ b/BruTile.Desktop.DbCache/BruTile.Desktop.DbCache.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\</SolutionDir>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Extensions for BruTile that require the full .Net Framework</Description>
     <PackageTags>tiling gis osm geo file ado.net</PackageTags>

--- a/BruTile.Desktop/BruTile.Desktop.csproj
+++ b/BruTile.Desktop/BruTile.Desktop.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\</SolutionDir>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Extensions for BruTile that require the full .Net Framework</Description>
     <PackageTags>tiling gis osm geo file ado.net</PackageTags>

--- a/BruTile.MbTiles/BruTile.MbTiles.csproj
+++ b/BruTile.MbTiles/BruTile.MbTiles.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\</SolutionDir>
-    <TargetFrameworks>net45;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Extension for BruTile to enable access to MapBox's tile store files (MbTiles)</Description>
     <PackageTags>tiling brutile mbtiles</PackageTags>

--- a/BruTile/BruTile.csproj
+++ b/BruTile/BruTile.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\</SolutionDir>
-    <TargetFrameworks>net45;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>BruTile is a C# library for GIS tile services such as those of Bing maps and OpenStreetMap</Description>
     <PackageTags>tiling gis osm geo</PackageTags>

--- a/Performance/BruTile.Performance.Desktop/BruTile.Performance.Desktop.csproj
+++ b/Performance/BruTile.Performance.Desktop/BruTile.Performance.Desktop.csproj
@@ -2,8 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFramework>net47</TargetFramework>
-    <TargetFrameworkToTest>net45</TargetFrameworkToTest>
+    <TargetFramework>net48</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Description>BruTile is a C# library for GIS tile services such as those of Bing maps and OpenStreetMap</Description>
     <PackageTags>tiling gis osm geo</PackageTags>

--- a/Samples/BruTile.Demo/BruTile.Demo.csproj
+++ b/Samples/BruTile.Demo/BruTile.Demo.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BruTile.Demo</RootNamespace>
     <AssemblyName>BruTile.Demo</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/Samples/BruTile.Samples.Common/BruTile.Samples.Common.csproj
+++ b/Samples/BruTile.Samples.Common/BruTile.Samples.Common.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFrameworks>net45;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Description>BruTile is a C# library for GIS tile services such as those of Bing maps and OpenStreetMap</Description>
     <PackageTags>tiling gis osm geo</PackageTags>

--- a/Samples/BruTile.Samples.MbTiles/BruTile.Samples.MbTiles.csproj
+++ b/Samples/BruTile.Samples.MbTiles/BruTile.Samples.MbTiles.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BruTile.Samples.MbTiles</RootNamespace>
     <AssemblyName>BruTile.Samples.MbTiles</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/Samples/BruTile.Samples.SimpleStaticMap/BruTile.Samples.SimpleStaticMap.csproj
+++ b/Samples/BruTile.Samples.SimpleStaticMap/BruTile.Samples.SimpleStaticMap.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BruTile.Samples.SimpleStaticMap</RootNamespace>
     <AssemblyName>BruTile.Samples.SimpleStaticMap</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Tests/BruTile.Desktop.Tests/BruTile.Desktop.Tests.csproj
+++ b/Tests/BruTile.Desktop.Tests/BruTile.Desktop.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFramework>net45</TargetFramework>
-    <TargetFrameworkToTest>net45</TargetFrameworkToTest>
+    <TargetFramework>net48</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <RootNamespace>BruTile.Tests</RootNamespace>
   </PropertyGroup>

--- a/Tests/BruTile.MbTiles.Tests/BruTile.MbTiles.Tests.csproj
+++ b/Tests/BruTile.MbTiles.Tests/BruTile.MbTiles.Tests.csproj
@@ -2,8 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFramework>net45</TargetFramework>
-    <TargetFrameworkToTest>net45</TargetFrameworkToTest>
+    <TargetFramework>net48</TargetFramework>
     <Description>BruTile is a C# library for GIS tile services such as those of Bing maps and OpenStreetMap</Description>
     <PackageTags>tiling gis osm geo</PackageTags>
     <Authors>Paul den Dulk, Felix Obermaier</Authors>

--- a/Tests/BruTile.Tests/BruTile.Tests.csproj
+++ b/Tests/BruTile.Tests/BruTile.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$(ProjectDir)..\..\</SolutionDir>
-    <TargetFramework>net45</TargetFramework>
-    <TargetFrameworkToTest>net45</TargetFrameworkToTest>
+    <TargetFramework>net48</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Description>BruTile is a C# library for GIS tile services such as those of Bing maps and OpenStreetMap</Description>
     <PackageTags>tiling gis osm geo</PackageTags>

--- a/Tools/GetVersionFromAssembly/GetVersionFromAssembly.csproj
+++ b/Tools/GetVersionFromAssembly/GetVersionFromAssembly.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.0" />
+    <PackageReference Update="Microsoft.NETCore.App" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
By removing net45 all published dlls will be only .netstandard. This is breaking change. The next release will be v4.

All tests and samples were upped to net48.

todo:
- All current netcoreapps should go to 3.1
- Tests should be set to netcoreapp3.1 (now net48)
- The two console samples should go to netcoreapp3.1
- The two forms samples should go to the new csproj format 
- Think about an alternative for forms samples. I would like to have something that builds and Windows and Mac, so that all the code builds and Windows and Mac. I looked at MAUI, but it seems early. Contributors will have to install specific prereleases. Perhaps just wait a bit longer. 


