### PR TITLE
Added support to customize the HttpClientHandler to add proxy server …

### DIFF
--- a/BruTile/Web/HttpClientBuilder.cs
+++ b/BruTile/Web/HttpClientBuilder.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+
+namespace BruTile.Web
+{
+    public static class HttpClientBuilder
+    {
+        public static HttpClientHandler HttpClientHandler { get; set; }
+
+
+        public static HttpClient Build()
+        {
+            if (HttpClientHandler is null)
+                return new HttpClient(HttpClientHandler, false);
+
+            return new HttpClient();
+        }
+    }
+}

--- a/BruTile/Web/HttpClientBuilder.cs
+++ b/BruTile/Web/HttpClientBuilder.cs
@@ -12,7 +12,7 @@ namespace BruTile.Web
 
         public static HttpClient Build()
         {
-            if (HttpClientHandler is null)
+            if (HttpClientHandler != null)
                 return new HttpClient(HttpClientHandler, false);
 
             return new HttpClient();

--- a/BruTile/Web/HttpTileProvider.cs
+++ b/BruTile/Web/HttpTileProvider.cs
@@ -10,7 +10,7 @@ namespace BruTile.Web
     {
         private readonly Func<Uri, byte[]> _fetchTile;
         private readonly IRequest _request;
-        private readonly HttpClient _httpClient = new HttpClient();
+        private readonly HttpClient _httpClient = BruTile.Web.HttpClientBuilder.Build();
 
         public HttpTileProvider(IRequest request = null, IPersistentCache<byte[]> persistentCache = null,
             Func<Uri, byte[]> fetchTile = null, string userAgent = null)

--- a/BruTile/Web/HttpTileSource.cs
+++ b/BruTile/Web/HttpTileSource.cs
@@ -11,7 +11,7 @@ namespace BruTile.Web
     {
         private readonly Func<Uri, byte[]> _fetchTile;
         private readonly IRequest _request;
-        private readonly HttpClient _httpClient = new HttpClient();
+        private readonly HttpClient _httpClient = BruTile.Web.HttpClientBuilder.Build();
 
         public HttpTileSource(ITileSchema tileSchema, string urlFormatter, IEnumerable<string> serverNodes = null,
             string apiKey = null, string name = null, IPersistentCache<byte[]> persistentCache = null,

--- a/Samples/BruTile.Samples.Common/Samples/GoogleMapsSample.cs
+++ b/Samples/BruTile.Samples.Common/Samples/GoogleMapsSample.cs
@@ -20,7 +20,7 @@ namespace BruTile.Samples.Common.Samples
 
         private static byte[] FetchGoogleTile(Uri arg)
         {
-            var httpClient = new HttpClient();
+            var httpClient = BruTile.Web.HttpClientBuilder.Build();
 
             httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Referer", "http://maps.google.com/");
             httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", @"Mozilla / 5.0(Windows; U; Windows NT 6.0; en - US; rv: 1.9.1.7) Gecko / 20091221 Firefox / 3.5.7");

--- a/Samples/BruTile.Samples.Common/Samples/MichelinWmtsSample.cs
+++ b/Samples/BruTile.Samples.Common/Samples/MichelinWmtsSample.cs
@@ -8,7 +8,7 @@ namespace BruTile.Samples.Common.Samples
     {
         public static ITileSource Create()
         {
-            var httpClient = new HttpClient();
+            var httpClient = BruTile.Web.HttpClientBuilder.Build();
             var stream = httpClient.GetStreamAsync("https://bertt.github.io/wmts/capabilities/michelin.xml").Result;
             var michelinTileSource = WmtsParser.Parse(stream).First();
             return michelinTileSource;

--- a/Samples/BruTile.Samples.SimpleStaticMap/Form1.cs
+++ b/Samples/BruTile.Samples.SimpleStaticMap/Form1.cs
@@ -11,7 +11,7 @@ namespace BruTile.Samples.SimpleStaticMap
     public partial class Form1 : Form
     {
         readonly Bitmap _buffer;
-        private readonly HttpClient _httpClient = new HttpClient();
+        private readonly HttpClient _httpClient = BruTile.Web.HttpClientBuilder.Build();
 
 
         //a list of resolutions in which the tiles are stored


### PR DESCRIPTION
…support

#51 #84
Added ability to add proxy server details

Example:
HttpClientHandler handler = new HttpClientHandler();
handler.UseDefaultCredentials = true;
BruTile.Web.HttpClientBuilder.HttpClientHandler = handler;