### PR TITLE
Fixed WmscRequest query string

### DIFF
--- a/BruTile/Wmsc/WmscRequest.cs
+++ b/BruTile/Wmsc/WmscRequest.cs
@@ -43,7 +43,14 @@ namespace BruTile.Wmsc
         public Uri GetUri(TileInfo info)
         {
             var url = new StringBuilder(_baseUrl.AbsoluteUri);
-            url.Append("&SERVICE=WMS");
+            if (String.IsNullOrWhiteSpace(_baseUrl.Query))
+            {
+                url.Append("?SERVICE=WMS");
+            }
+            else
+            {
+                url.Append("&SERVICE=WMS");
+            }
             if (!string.IsNullOrEmpty(_version)) url.AppendFormat("&VERSION={0}", _version);
             url.Append("&REQUEST=GetMap");
             url.AppendFormat("&BBOX={0}", TileTransform.TileToWorld(new TileRange(info.Index.Col, info.Index.Row), info.Index.Level, _schema));


### PR DESCRIPTION
This PR fixes the appending of the query string.

I wanted to use this service in MapsUi: `https://geoservices5.civis.bz.it/geoserver/p_bz-Cadastre/ows`

When using it like above, the query string got added like this:
`https://geoservices5.civis.bz.it/geoserver/p_bz-Cadastre/ows&SERVICE=WMS&REQUEST=GetMap&BBOX=...` wich resulted in an error 404.

I then added `?REQUEST=GetCapabilities` to my service url:
`https://geoservices5.civis.bz.it/geoserver/p_bz-Cadastre/ows?REQUEST=GetCapabilities`
which created this url: `/geoserver/p_bz-Cadastre/ows?REQUEST=GetCapabilities&SERVICE=WMS&REQUEST=GetMap&BBOX=`
and this error:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<ows:ExceptionReport xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/ows https://geoservices5.civis.bz.it/geoserver/schemas/ows/1.0.0/owsExceptionReport.xsd">
	<ows:Exception exceptionCode="InvalidParameterValue" locator="request">
		<ows:ExceptionText>Single value expected for request parameter request but instead found: [GetCapabilities, GetMap]</ows:ExceptionText>
	</ows:Exception>
</ows:ExceptionReport>
```

There are 2 workarounds:

- Add request as lowercase string as in the [wms sample](https://github.com/Mapsui/Mapsui/blob/61e67bbc8994f470df0acf26590bf7287d7360bf/Samples/Mapsui.Samples.Common/Maps/Data/WmsSample.cs#L32)
`https://geoservices5.civis.bz.it/geoserver/p_bz-Cadastre/ows?request=GetCapabilities`
In this case there is still a `REQUEST=GetMap` added and the lowercase request makes some confusion.

- Add any dummy parameter
`https://geoservices5.civis.bz.it/geoserver/p_bz-Cadastre/ows?dummy`

With this PR you can use the url without query parameters as source (e.g. `https://geoservices5.civis.bz.it/geoserver/p_bz-Cadastre/ows`) which makes it more obvious.


We could further improve it to completely replace the existing query parameters. I already prepared a solution, can push it if you decide to go this way (it uses an utility class named [QueryString](https://github.com/WindowsNotifications/QueryString.NET/blob/master/QueryString/QueryString.cs)):

```csharp
            var url = new UriBuilder(_baseUrl.AbsoluteUri);
            var query = new QueryString();

            query.Set("SERVICE", "WMS");
            if (!string.IsNullOrEmpty(_version)) query.Set("VERSION", _version);
            query.Set("REQUEST", "GetMap");
            query.Set("BBOX", TileTransform.TileToWorld(new TileRange(info.Index.Col, info.Index.Row), info.Index.Level, _schema).ToString());
            query.Set("FORMAT", _schema.Format);
            query.Set("WIDTH", _schema.GetTileWidth(info.Index.Level).ToString());
            query.Set("HEIGHT", _schema.GetTileHeight(info.Index.Level).ToString());
            var crsParameterName = !string.IsNullOrEmpty(_version) && string.CompareOrdinal(_version, "1.3.0") >= 0 ? "CRS" : "SRS";
            query.Set(crsParameterName, _schema.Srs);
            query.Set("LAYERS", ToCommaSeparatedValues(_layers));
            if (_styles != null && _styles.Count > 0) query.Set("STYLES", ToCommaSeparatedValues(_styles));
            AppendCustomParameters(query);
            url.Query = query.ToString();
            return new Uri(url.ToString());
```
