### PR TITLE
GitHub Actions: upload nupkgs as artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,8 @@ jobs:
       run: dotnet format BruTile.sln --verbosity normal --verify-no-changes
     - name: Test
       run: dotnet test $SOLUTION --configuration Release --no-restore --verbosity normal
+    - name: Upload packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: nupkg
+        path: BruTile*/bin/Release/*.nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.402
+        dotnet-version: 7.0.x
     - name: Build
       run: dotnet build $SOLUTION --configuration Release -p:Version=$(git describe --tags)
     - name: check the formatting

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,16 +18,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.402
     - name: Build
-      run: dotnet build $SOLUTION --configuration Release
+      run: dotnet build $SOLUTION --configuration Release -p:Version=$(git describe --tags)
     - name: check the formatting
       run: dotnet format BruTile.sln --verbosity normal --verify-no-changes
     - name: Test
-      run: dotnet test $SOLUTION --configuration Release --no-restore --verbosity normal
+      run: dotnet test $SOLUTION --configuration Release -p:Version=$(git describe --tags) --no-restore --verbosity normal
     - name: Upload packages
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build on Windows
 
 on:
   push:
-    branches: [ master ]
+    branches: [ '**' ]
   pull_request:
     branches: [ '**' ]
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
This fixes #197.

In fact the current GHA build already generates packages, so I simply add a step that uploads them as artifacts, and set a version (via "git describe") that is unique for every commit.

In addition I update the .NET version that is used for the build from 6 to 7, and enable the GHA workflow for pushes to every branch, not just master.