### PR TITLE
Fix file lock

### DIFF
--- a/BruTile.MbTiles/MbTilesTileSource.cs
+++ b/BruTile.MbTiles/MbTilesTileSource.cs
@@ -50,8 +50,7 @@ namespace BruTile.MbTiles
         {
             _connectionString = connectionString;
 
-            using (var connection = new SQLiteConnectionWithLock(connectionString))
-            using (connection.Lock())
+            using (var connection = new SQLiteConnection(connectionString))
             {
                 Schema = schema ?? ReadSchemaFromDatabase(connection, determineZoomLevelsFromTilesTable);
                 Type = type == MbTilesType.None ? ReadType(connection) : type;
@@ -71,7 +70,7 @@ namespace BruTile.MbTiles
             }
         }
 
-        private static ITileSchema ReadSchemaFromDatabase(SQLiteConnectionWithLock connection, bool determineZoomLevelsFromTilesTable)
+        private static ITileSchema ReadSchemaFromDatabase(SQLiteConnection connection, bool determineZoomLevelsFromTilesTable)
         {
             // ReadZoomLevels can return null. This is no problem. GlobalSphericalMercator will initialize with default values
             var zoomLevels = ReadZoomLevels(connection);
@@ -87,7 +86,7 @@ namespace BruTile.MbTiles
             return new GlobalSphericalMercator(format.ToString(), YAxis.TMS, zoomLevels, extent: extent);
         }
 
-        private static int[] ReadZoomLevels(SQLiteConnectionWithLock connection)
+        private static int[] ReadZoomLevels(SQLiteConnection connection)
         {
             var zoomMin = ReadInt(connection, "minzoom");
             if (zoomMin == null) return null;


### PR DESCRIPTION
## The problem
After an mbtiles file was opened, the file was locked and could not be be opened by another application.

## The solution
This problem could be solved by replacing the `SQLiteConnectionWithLock` with  `SQLiteConnection`. The 'Lock' in `SQLiteConnectionWithLock` does not seem to relate to a file lock by to a connection access lock. Also, that Lock is in a using and should thus be unlocked (and looking at the sql-lite-net source it is unlocked) Nevertheless, replacing it solved  the problem. Perhaps there is a bug in the way SQLiteConnectionWithLock is Dispose. Note, SQLiteConnectionWithLock was only used while reading the metadata (which is only once when opening the file) and not while fetching tiles. I don't really see why the lock was needed since everything in the file provider is read only.