### PR TITLE
Update WmtsParser.cs: adding a test if a layer has no Style

### DIFF
--- a/BruTile/Wmts/WmtsParser.cs
+++ b/BruTile/Wmts/WmtsParser.cs
@@ -82,6 +82,9 @@ namespace BruTile.Wmts
 
                 foreach (var tileMatrixLink in layer.TileMatrixSetLink)
                 {
+                    if (layer.Style == null)
+                        continue;
+                    
                     foreach (var style in layer.Style)
                     {
                         foreach (var format in layer.Format)


### PR DESCRIPTION
The idea is to avoid NullReferenceException that cancel parsing Continue parsing instead