### PR TITLE
HttpTileProvider: add the possibility to provide credentials for authentication

### DIFF
--- a/BruTile/Web/HttpTileProvider.cs
+++ b/BruTile/Web/HttpTileProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) BruTile developers team. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using BruTile.Cache;
@@ -11,14 +12,26 @@ namespace BruTile.Web
     {
         private readonly Func<Uri, Task<byte[]>> _fetchTile;
         private readonly IRequest _request;
-        private readonly HttpClient _httpClient = HttpClientBuilder.Build();
+        private readonly HttpClient _httpClient;
 
         public HttpTileProvider(IRequest request = null, IPersistentCache<byte[]> persistentCache = null,
-            Func<Uri, Task<byte[]>> fetchTile = null, string userAgent = null)
+            Func<Uri, Task<byte[]>> fetchTile = null, string userAgent = null, ICredentials credentials = null)
         {
             _request = request ?? new NullRequest();
             PersistentCache = persistentCache ?? new NullCache();
             _fetchTile = fetchTile ?? FetchTileAsync;
+            var httpClientHandler = new HttpClientHandler();
+            try
+            {
+                // Blazor does not support this,
+                if (credentials != null)
+                    httpClientHandler.Credentials = credentials;
+            }
+            catch (PlatformNotSupportedException)
+            {
+            }
+
+            _httpClient = new HttpClient(httpClientHandler);
             _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent ?? "BruTile Tile Library");
         }
 


### PR DESCRIPTION
Note that this PR in principle shares the binary-compatibility issues of #214 (see #216), since it also adds an optional parameter to a constructor.
However, in contrast to #214, this constructor is not actually used in the Mapsui libraries (only in the samples). Therefore it does not introduce any compatibility problems with Mapsui.
Backwards compatibility on the source level is maintained, of course: Code that compiled with the old version will still compile with the new version.