### PR TITLE
LegendUrl width & heigth attributes are optional

### DIFF
--- a/BruTile/Wms/LegendURL.cs
+++ b/BruTile/Wms/LegendURL.cs
@@ -15,13 +15,13 @@ namespace BruTile.Wms
 
         public LegendURL(XElement node, string ns)
         {
-            var widthAttribute = node.Attribute(XName.Get("width"))
-                ?? throw new System.Exception("Width node is null in xml");
-            Width = int.Parse(widthAttribute.Value, NumberFormatInfo.InvariantInfo);
+            var widthAttribute = node.Attribute(XName.Get("width"));
+            if (widthAttribute != null)
+                Width = int.Parse(widthAttribute.Value, NumberFormatInfo.InvariantInfo);
 
-            var heightAttribute = node.Attribute(XName.Get("height"))
-                ?? throw new System.Exception("Height node is null in xml");
-            Height = int.Parse(heightAttribute.Value, NumberFormatInfo.InvariantInfo);
+            var heightAttribute = node.Attribute(XName.Get("height"));
+            if (heightAttribute != null)
+                Height = int.Parse(heightAttribute.Value, NumberFormatInfo.InvariantInfo);
 
             var element = node.Element(XName.Get("Format", ns));
             Format = element?.Value ?? "png";


### PR DESCRIPTION
Hi,
I found out that `BruTile.Wms.LegendUrl` constructor throws an exception when width or height attribut is missing on LegendUrl tag. This seem to be in contradiction with OCS WMS standard, which says that thehe attributes are optional. See chapter 7.2.4.6.5 and LegendUrl tag annotation (on page 69) in OGC WMS implementation specification.

OpenGIS Web Map Service (WMS) Implementation Specification can be downloaded here: https://www.ogc.org/standard/wms/.

Regards,
Petr