### PR TITLE
Remove referer again

### DIFF
--- a/BruTile/Web/HttpTileSource.cs
+++ b/BruTile/Web/HttpTileSource.cs
@@ -16,20 +16,18 @@ namespace BruTile.Web
 
         public HttpTileSource(ITileSchema tileSchema, string urlFormatter, IEnumerable<string> serverNodes = null,
             string apiKey = null, string name = null, IPersistentCache<byte[]> persistentCache = null,
-            Func<Uri, Task<byte[]>> tileFetcher = null, Attribution attribution = null, string userAgent = null, string referer = null)
-            : this(tileSchema, new BasicRequest(urlFormatter, serverNodes, apiKey), name, persistentCache, tileFetcher, attribution, userAgent, referer)
+            Func<Uri, Task<byte[]>> tileFetcher = null, Attribution attribution = null, string userAgent = null)
+            : this(tileSchema, new BasicRequest(urlFormatter, serverNodes, apiKey), name, persistentCache, tileFetcher, attribution, userAgent)
         { }
 
         public HttpTileSource(ITileSchema tileSchema, IRequest request, string name = null,
             IPersistentCache<byte[]> persistentCache = null, Func<Uri, Task<byte[]>> tileFetcher = null,
-            Attribution attribution = null, string userAgent = null, string referer = null)
+            Attribution attribution = null, string userAgent = null)
         {
             _request = request ?? new NullRequest();
             PersistentCache = persistentCache ?? new NullCache();
             _fetchTile = tileFetcher ?? FetchTileAsync;
             _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent ?? "If you use BruTile please specify a user-agent specific to your app");
-            if (referer is not null)
-                _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Referer", referer);
             Schema = tileSchema;
             Name = name ?? string.Empty;
             Attribution = attribution ?? new Attribution();

--- a/BruTile/Web/HttpTileSource.cs
+++ b/BruTile/Web/HttpTileSource.cs
@@ -58,6 +58,16 @@ namespace BruTile.Web
             return bytes;
         }
 
+        public void AddHeader(string key, string value)
+        {
+            _httpClient.DefaultRequestHeaders.TryAddWithoutValidation(key, value);
+        }
+
+        public IEnumerable<string> GetHeaders(string key)
+        {
+            return _httpClient.DefaultRequestHeaders.GetValues(key);
+        }
+        
         private async Task<byte[]> FetchTileAsync(Uri arg)
         {
             return await _httpClient.GetByteArrayAsync(arg).ConfigureAwait(false);

--- a/BruTile/Web/HttpTileSource.cs
+++ b/BruTile/Web/HttpTileSource.cs
@@ -67,7 +67,7 @@ namespace BruTile.Web
         {
             return _httpClient.DefaultRequestHeaders.GetValues(key);
         }
-        
+
         private async Task<byte[]> FetchTileAsync(Uri arg)
         {
             return await _httpClient.GetByteArrayAsync(arg).ConfigureAwait(false);

--- a/Tests/BruTile.Tests/Web/HttpTileSourceTests.cs
+++ b/Tests/BruTile.Tests/Web/HttpTileSourceTests.cs
@@ -2,9 +2,11 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using BruTile.Predefined;
+using BruTile.Web;
 using NUnit.Framework;
 using RichardSzalay.MockHttp;
 
@@ -30,6 +32,19 @@ namespace BruTile.Tests.Web
             // Assert
             Console.WriteLine("Durations: {0:0} milliseconds", DateTime.Now.Subtract(timeStart).TotalMilliseconds);
             Assert.AreEqual(64, tiles.Length);
+        }
+
+        [Test]
+        public void TestAddHeader()
+        {
+            // Arrange
+            var tileSource = new HttpTileSource(new GlobalSphericalMercator(), "https://tile.openstreetmap.org/{z}/{x}/{y}.png");
+
+            // Act
+            tileSource.AddHeader("Referer", "test-referer");  
+
+            // Assert
+            Assert.AreEqual("test-referer", tileSource.GetHeaders("Referer").FirstOrDefault());            
         }
     }
 }

--- a/Tests/BruTile.Tests/Web/HttpTileSourceTests.cs
+++ b/Tests/BruTile.Tests/Web/HttpTileSourceTests.cs
@@ -41,10 +41,10 @@ namespace BruTile.Tests.Web
             var tileSource = new HttpTileSource(new GlobalSphericalMercator(), "https://tile.openstreetmap.org/{z}/{x}/{y}.png");
 
             // Act
-            tileSource.AddHeader("Referer", "test-referer");  
+            tileSource.AddHeader("Referer", "test-referer");
 
             // Assert
-            Assert.AreEqual("test-referer", tileSource.GetHeaders("Referer").FirstOrDefault());            
+            Assert.AreEqual("test-referer", tileSource.GetHeaders("Referer").FirstOrDefault());
         }
     }
 }


### PR DESCRIPTION
Because of #216

I did not see a simple solution. An init property is not possible because of .netstandard. With a regular property you want to override the referer, but that is not how it works in the HttpClient, every time you call the line below a new entry is added:

```csharp
_httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Referer", referer);
```
It would be possible to add a method, that you could use to keep adding entries. But it would not be clear what is it doing exactly. A better solution would be a proper redesign, but that is not something I want to do now with BruTile. I would rather add a whole new solution next to the HttpTileSource.
