### PR TITLE
Try to fix problems caused by an empty style identifier in WMTS 2.0.0

### DIFF
--- a/BruTile/Wmts/WmtsCapabilitiesParser.cs
+++ b/BruTile/Wmts/WmtsCapabilitiesParser.cs
@@ -87,6 +87,12 @@ public class WmtsCapabilitiesParser
 
                 foreach (var style in layer.Style)
                 {
+                    var styleName = "default";
+                    if (style.Identifier.Value != null)
+                    {
+                        styleName = style.Identifier.Value;
+                    }
+
                     foreach (var format in layer.Format)
                     {
                         if (!format.StartsWith("image/")) continue;
@@ -103,7 +109,8 @@ public class WmtsCapabilitiesParser
                                 format,
                                 capabilities.ServiceIdentification.ServiceTypeVersion.First(),
                                 layer.Identifier.Value,
-                                style.Identifier.Value,
+                                //style.Identifier.Value,
+                                styleName,
                                 tileMatrixLink.TileMatrixSet);
 
                             wmtsRequest = new WmtsUrlBuilder(resourceUrls, tileSchema.LevelToIdentifier);
@@ -112,14 +119,14 @@ public class WmtsCapabilitiesParser
                         {
                             var resourceUrls = CreateResourceUrlsFromResourceUrlNode(
                                 layer.ResourceURL,
-                                style.Identifier.Value,
+                                //style.Identifier.Value,
+                                styleName,
                                 tileMatrixLink.TileMatrixSet);
 
                             wmtsRequest = new WmtsUrlBuilder(resourceUrls, tileSchema.LevelToIdentifier);
                         }
 
-                        //var layerName = layer.Identifier.Value;
-                        var styleName = style.Identifier.Value;
+                        //var layerName = layer.Identifier.Value;                  
 
                         var schema = tileSchema.CreateSpecific(title, identifier, @abstract, tileMatrixSet, styleName, format);
                         var tileSource = new HttpTileSource(schema, wmtsRequest, name: title);


### PR DESCRIPTION
I tried to create a solution for #249. Empty style identifiers are replaced by "default". At least for Berlin it solves the problem but I do not know if it is a good general solution.