### PR TITLE
Made resourceType string instead of enum 

### DIFF
--- a/BruTile/Wmts/Generated/xlink_owscommon_wmtsGetCapabilities_response.cs
+++ b/BruTile/Wmts/Generated/xlink_owscommon_wmtsGetCapabilities_response.cs
@@ -48,8 +48,8 @@ namespace BruTile.Wmts.Generated
     }
 
     /// <remarks/>
-    [XmlInclude(typeof (ReferenceType))]
-    [XmlInclude(typeof (ServiceReferenceType))]
+    [XmlInclude(typeof(ReferenceType))]
+    [XmlInclude(typeof(ServiceReferenceType))]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.0.30319.17929")]
     [System.Diagnostics.DebuggerStepThroughAttribute()]
 
@@ -208,7 +208,7 @@ namespace BruTile.Wmts.Generated
 
         /// <remarks/>
         [XmlAttribute()]
-        public URLTemplateTypeResourceType resourceType { get; set; }
+        public string resourceType { get; set; }
 
         /// <remarks/>
         [XmlAttribute()]
@@ -216,21 +216,7 @@ namespace BruTile.Wmts.Generated
     }
 
     /// <remarks/>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.0.30319.17929")]
-
-    [XmlType(AnonymousType = true, Namespace = "http://www.opengis.net/wmts/1.0")]
-    public enum URLTemplateTypeResourceType
-    {
-
-        /// <remarks/>
-        tile,
-
-        /// <remarks/>
-        FeatureInfo,
-    }
-
-    /// <remarks/>
-    [XmlInclude(typeof (ContentsType))]
+    [XmlInclude(typeof(ContentsType))]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.0.30319.17929")]
 
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -261,7 +247,7 @@ namespace BruTile.Wmts.Generated
     }
 
     /// <remarks/>
-    [XmlInclude(typeof (LayerType))]
+    [XmlInclude(typeof(LayerType))]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.0.30319.17929")]
 
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -298,7 +284,7 @@ namespace BruTile.Wmts.Generated
         }
 
         /// <remarks/>
-        [XmlElement("BoundingBox", typeof (BoundingBoxType))]
+        [XmlElement("BoundingBox", typeof(BoundingBoxType))]
         public BoundingBoxType[] Items
         {
             get { return this.itemsField; }
@@ -349,7 +335,7 @@ namespace BruTile.Wmts.Generated
         {
             var name = reader.Name;
             if (!string.IsNullOrEmpty(reader.Prefix))
-                name = name.Substring(reader.Prefix.Length+1);
+                name = name.Substring(reader.Prefix.Length + 1);
             System.Diagnostics.Debug.Assert(name == "BoundingBox" || name == "WGS84BoundingBox");
 
             var isEmpty = reader.IsEmptyElement;
@@ -629,12 +615,12 @@ Namespace = "http://www.opengis.net/wmts/1.0")]
     }
 
     /// <remarks/>
-    [XmlInclude(typeof (DatasetDescriptionSummaryBaseType))]
-    [XmlInclude(typeof (LayerType))]
-    [XmlInclude(typeof (BasicIdentificationType))]
-    [XmlInclude(typeof (ManifestType))]
-    [XmlInclude(typeof (ReferenceGroupType))]
-    [XmlInclude(typeof (IdentificationType))]
+    [XmlInclude(typeof(DatasetDescriptionSummaryBaseType))]
+    [XmlInclude(typeof(LayerType))]
+    [XmlInclude(typeof(BasicIdentificationType))]
+    [XmlInclude(typeof(ManifestType))]
+    [XmlInclude(typeof(ReferenceGroupType))]
+    [XmlInclude(typeof(IdentificationType))]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.0.30319.17929")]
 
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -739,9 +725,9 @@ Namespace = "http://www.opengis.net/wmts/1.0")]
     }
 
     /// <remarks/>
-    [XmlInclude(typeof (ManifestType))]
-    [XmlInclude(typeof (ReferenceGroupType))]
-    [XmlInclude(typeof (IdentificationType))]
+    [XmlInclude(typeof(ManifestType))]
+    [XmlInclude(typeof(ReferenceGroupType))]
+    [XmlInclude(typeof(IdentificationType))]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.0.30319.17929")]
 
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -786,8 +772,8 @@ Namespace = "http://www.opengis.net/wmts/1.0")]
         private string[] availableCRSField;
 
         /// <remarks/>
-        [XmlElement("BoundingBox", typeof (BoundingBoxType))]
-        [XmlElement("WGS84BoundingBox", typeof (WGS84BoundingBoxType))]
+        [XmlElement("BoundingBox", typeof(BoundingBoxType))]
+        [XmlElement("WGS84BoundingBox", typeof(WGS84BoundingBoxType))]
         public BoundingBoxType[] Items
         {
             get { return this.itemsField; }
@@ -1016,7 +1002,7 @@ Namespace = "http://www.opengis.net/wmts/1.0")]
     }
 
     /// <remarks/>
-    [XmlInclude(typeof (RequestMethodType))]
+    [XmlInclude(typeof(RequestMethodType))]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.0.30319.17929")]
 
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -1179,7 +1165,7 @@ Namespace = "http://www.opengis.net/wmts/1.0")]
     }
 
     /// <remarks/>
-    [XmlInclude(typeof (DomainType))]
+    [XmlInclude(typeof(DomainType))]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.0.30319.17929")]
 
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -1206,7 +1192,7 @@ Namespace = "http://www.opengis.net/wmts/1.0")]
         private MetadataType[] metadataField;
 
         /// <remarks/>
-        [XmlArrayItem("Range", typeof (RangeType), IsNullable = false), XmlArrayItem("Value", typeof (ValueType), IsNullable = false)]
+        [XmlArrayItem("Range", typeof(RangeType), IsNullable = false), XmlArrayItem("Value", typeof(ValueType), IsNullable = false)]
         public object[] AllowedValues { get; set; }
 
         /// <remarks/>
@@ -1687,9 +1673,9 @@ Namespace = "http://www.opengis.net/wmts/1.0")]
         }
 
         /// <remarks/>
-        [XmlElement("BoundingBox", typeof (BoundingBoxType),
+        [XmlElement("BoundingBox", typeof(BoundingBoxType),
             Namespace = "http://www.opengis.net/ows/1.1")]
-        [XmlElement("WGS84BoundingBox", typeof (WGS84BoundingBoxType),
+        [XmlElement("WGS84BoundingBox", typeof(WGS84BoundingBoxType),
             Namespace = "http://www.opengis.net/ows/1.1")]
         public BoundingBoxType Item
         {
@@ -2293,8 +2279,8 @@ Namespace = "http://www.opengis.net/wmts/1.0")]
         private ItemsChoiceType[] itemsElementNameField;
 
         /// <remarks/>
-        [XmlElement("Get", typeof (RequestMethodType))]
-        [XmlElement("Post", typeof (RequestMethodType))]
+        [XmlElement("Get", typeof(RequestMethodType))]
+        [XmlElement("Post", typeof(RequestMethodType))]
         [XmlChoiceIdentifier("ItemsElementName")]
         public RequestMethodType[] Items
         {
@@ -2651,10 +2637,10 @@ Namespace = "http://www.opengis.net/wmts/1.0")]
         }
 
         /// <remarks/>
-        [XmlElement("arc", typeof (arcType))]
-        [XmlElement("locator", typeof (locatorType))]
-        [XmlElement("resource", typeof (resourceType))]
-        [XmlElement("title", typeof (titleEltType))]
+        [XmlElement("arc", typeof(arcType))]
+        [XmlElement("locator", typeof(locatorType))]
+        [XmlElement("resource", typeof(resourceType))]
+        [XmlElement("title", typeof(titleEltType))]
         public object[] Items
         {
             get { return this.itemsField; }
@@ -3064,8 +3050,8 @@ Namespace = "http://www.opengis.net/wmts/1.0")]
         private object[] itemsField;
 
         /// <remarks/>
-        [XmlElement("Range", typeof (RangeType))]
-        [XmlElement("Value", typeof (ValueType))]
+        [XmlElement("Range", typeof(RangeType))]
+        [XmlElement("Value", typeof(ValueType))]
         public object[] Items
         {
             get { return this.itemsField; }
@@ -3074,7 +3060,7 @@ Namespace = "http://www.opengis.net/wmts/1.0")]
     }
 
     /// <remarks/>
-    [XmlInclude(typeof (ServiceReferenceType))]
+    [XmlInclude(typeof(ServiceReferenceType))]
     [System.CodeDom.Compiler.GeneratedCodeAttribute("xsd", "4.0.30319.17929")]
 
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -3182,8 +3168,8 @@ Namespace = "http://www.opengis.net/wmts/1.0")]
         private object itemField;
 
         /// <remarks/>
-        [XmlElement("RequestMessage", typeof (object))]
-        [XmlElement("RequestMessageReference", typeof (string), DataType = "anyURI")]
+        [XmlElement("RequestMessage", typeof(object))]
+        [XmlElement("RequestMessageReference", typeof(string), DataType = "anyURI")]
         public object Item
         {
             get { return this.itemField; }
@@ -3250,7 +3236,7 @@ Namespace = "http://www.opengis.net/wmts/1.0")]
         }
 
         /// <remarks/>
-        [XmlArrayItem("Theme", typeof (Theme[]), IsNullable = false)]
+        [XmlArrayItem("Theme", typeof(Theme[]), IsNullable = false)]
         public Theme[][] Themes
         {
             get { return this.themesField; }

--- a/BruTile/Wmts/ResourceUrl.cs
+++ b/BruTile/Wmts/ResourceUrl.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) BruTile developers team. All rights reserved. See License.txt in the project root for license information.
 
-using BruTile.Wmts.Generated;
-
 namespace BruTile.Wmts;
 
 public class ResourceUrl
 {
     public string Format { get; set; }
-    public URLTemplateTypeResourceType ResourceType { get; set; }
+    public string ResourceType { get; set; }
     public string Template { get; set; }
 }

--- a/BruTile/Wmts/WmtsCapabilitiesParser.cs
+++ b/BruTile/Wmts/WmtsCapabilitiesParser.cs
@@ -170,7 +170,7 @@ public class WmtsCapabilitiesParser
             Template = s.Key.Equals("kvp", StringComparison.CurrentCultureIgnoreCase) ?
                     CreateKvpFormatter(s.Value, format, version, layer, style, tileMatrixSet) :
                     CreateRestfulFormatter(s.Value, format, style, tileMatrixSet),
-            ResourceType = URLTemplateTypeResourceType.tile,
+            ResourceType = "tile",
             Format = format
         });
     }

--- a/Tests/BruTile.Tests/BruTile.Tests.csproj
+++ b/Tests/BruTile.Tests/BruTile.Tests.csproj
@@ -54,6 +54,9 @@
 		<None Update="Resources\Wms\wms_topplus_web_open.xml">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<None Update="Resources\Wmts\capabilities_with_tilejson.xml">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<None Update="Resources\Wmts\wmts-capabilities-arcgis-server-doggersbank.xml">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>

--- a/Tests/BruTile.Tests/Resources/Wmts/capabilities_with_tilejson.xml
+++ b/Tests/BruTile.Tests/Resources/Wmts/capabilities_with_tilejson.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd" version="1.0.0">
+    <!-- Service Identification --> 
+    <ows:ServiceIdentification>
+        <ows:Title>Mars_Viking_MDIM21_ClrMosaic_global_232m</ows:Title>
+        <ows:ServiceType>OGC WMTS</ows:ServiceType>
+        <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+    </ows:ServiceIdentification> <!-- Operations Metadata --> 
+    <ows:OperationsMetadata>
+        <ows:Operation name="GetCapabilities">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get xlink:href="https://api.nasa.gov/mars-wmts/catalog/Mars_Viking_MDIM21_ClrMosaic_global_232m/1.0.0/WMTSCapabilities.xml">
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>RESTful</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                    
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+        <ows:Operation name="GetTile">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get xlink:href="https://api.nasa.gov/mars-wmts/catalog/Mars_Viking_MDIM21_ClrMosaic_global_232m/1.0.0/">
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>RESTful</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                    
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+    </ows:OperationsMetadata> 
+    <Contents>
+        <!--Layer--> 
+        <Layer>
+            <ows:Title>Mars_Viking_MDIM21_ClrMosaic_global_232m</ows:Title> 
+            <ows:Identifier>Mars_Viking_MDIM21_ClrMosaic_global_232m</ows:Identifier>
+            <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::104905">
+                <ows:LowerCorner>-180.0 -90.0</ows:LowerCorner>
+                <ows:UpperCorner>180.0 90.0</ows:UpperCorner>
+            </ows:BoundingBox>
+            <ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
+                <ows:LowerCorner>-180.0 -90.0</ows:LowerCorner>
+                <ows:UpperCorner>180.0 90.0</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            
+            <Style isDefault="true">
+                <ows:Title>Default Style</ows:Title>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/jpg</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>default028mm</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/jpg" resourceType="TileJson" template="https://api.nasa.gov/mars-wmts/catalog/Mars_Viking_MDIM21_ClrMosaic_global_232m/1.0.0//{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"/>
+            <!--<ResourceURL format="image/jpg" resourceType="TileJson" template="https://api.nasa.gov/mars-wmts/catalog/Mars_Viking_MDIM21_ClrMosaic_global_232m/1.0.0//{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}"/>-->
+        </Layer> <!--TileMatrixSet-->
+        <TileMatrixSet>
+            <ows:Title>default</ows:Title>
+            <ows:Abstract>The tile matrix set that has scale values calculated based on the dpi defined by OGC specification (dpi assumes 0.28mm as the physical distance of a pixel).</ows:Abstract> 
+            <ows:Identifier>default028mm</ows:Identifier>
+            <ows:SupportedCRS>urn:ogc:def:crs:EPSG::104905</ows:SupportedCRS>
+            <TileMatrix><ows:Identifier>0</ows:Identifier><ScaleDenominator>2.7922763629807472E+08</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>2.0</MatrixWidth><MatrixHeight>1.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>1</ows:Identifier><ScaleDenominator>1.3961381814903736E+08</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>4.0</MatrixWidth><MatrixHeight>2.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>2</ows:Identifier><ScaleDenominator>6.9806909074518681E+07</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>8.0</MatrixWidth><MatrixHeight>4.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>3</ows:Identifier><ScaleDenominator>3.4903454537259340E+07</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>16.0</MatrixWidth><MatrixHeight>8.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>4</ows:Identifier><ScaleDenominator>1.7451727268629670E+07</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>32.0</MatrixWidth><MatrixHeight>16.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>5</ows:Identifier><ScaleDenominator>8.7258636343148351E+06</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>64.0</MatrixWidth><MatrixHeight>32.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>6</ows:Identifier><ScaleDenominator>4.3629318171574175E+06</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>128.0</MatrixWidth><MatrixHeight>64.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>7</ows:Identifier><ScaleDenominator>2.1814659085787088E+06</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>256.0</MatrixWidth><MatrixHeight>128.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>8</ows:Identifier><ScaleDenominator>1.0907329542893544E+06</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>512.0</MatrixWidth><MatrixHeight>256.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>9</ows:Identifier><ScaleDenominator>5.4536647714467719E+05</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>1024.0</MatrixWidth><MatrixHeight>512.0</MatrixHeight></TileMatrix>
+
+            <!--<TileMatrix>
+                <ows:Identifier>0</ows:Identifier> 
+                <ScaleDenominator>2.3623511904761901E8</ScaleDenominator>
+                <TopLeftCorner>-180.0 90.0</TopLeftCorner> 
+                <TileWidth>256</TileWidth> 
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>3</MatrixWidth> 
+                <MatrixHeight>2</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>1</ows:Identifier> 
+                <ScaleDenominator>1.1811755952380951E8</ScaleDenominator>
+                <TopLeftCorner>-180.0 90.0</TopLeftCorner> 
+                <TileWidth>256</TileWidth> 
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>5</MatrixWidth> 
+                <MatrixHeight>3</MatrixHeight>
+            </TileMatrix>
+            -->
+            
+        </TileMatrixSet>
+    </Contents>
+    <ServiceMetadataURL xlink:href="https://api.nasa.gov/mars-wmts/catalog/Mars_Viking_MDIM21_ClrMosaic_global_232m/1.0.0/WMTSCapabilities.xml"/> 
+</Capabilities>

--- a/Tests/BruTile.Tests/Wmts/WmtsTests.cs
+++ b/Tests/BruTile.Tests/Wmts/WmtsTests.cs
@@ -10,7 +10,6 @@ using BruTile.Cache;
 using BruTile.Tests.Utilities;
 using BruTile.Web;
 using BruTile.Wmts;
-using BruTile.Wmts.Generated;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
@@ -115,17 +114,17 @@ public class WmtsTests
             new() {
                 Format = "image/jpeg",
                 Template = "http://maps1.wien.gv.at/wmts/lb/farbe/google3857/{TileMatrix}/{TileRow}/{TileCol}.jpeg",
-                ResourceType = URLTemplateTypeResourceType.tile
+                ResourceType = "tile",
             },
             new() {
                 Format = "image/jpeg",
                 Template = "http://maps2.wien.gv.at/wmts/lb/farbe/google3857/{TileMatrix}/{TileRow}/{TileCol}.jpeg",
-                ResourceType = URLTemplateTypeResourceType.tile
+                ResourceType = "tile",
             },
             new() {
                 Format = "image/jpeg",
                 Template = "http://maps3.wien.gv.at/wmts/lb/farbe/google3857/{TileMatrix}/{TileRow}/{TileCol}.jpeg",
-                ResourceType = URLTemplateTypeResourceType.tile
+                ResourceType = "tile",
             }
         };
         return resourceUrls;
@@ -264,5 +263,14 @@ public class WmtsTests
 
         // Assert
         Assert.NotNull(tileSource.PersistentCache);
+    }
+
+    [Test]
+    public void TestParsingCapabilitiesWithTileJson()
+    {
+        // Arrange
+        using var stream = File.OpenRead(Path.Combine(Paths.AssemblyDirectory, "Resources", "Wmts", "capabilities_with_tilejson.xml"));
+        IEnumerable<HttpTileSource> tileSources = null;
+        Assert.DoesNotThrow(() => tileSources = WmtsCapabilitiesParser.Parse(stream));
     }
 }


### PR DESCRIPTION
Made resourceType string instead of enum because custom values are allowed according to the spec, it crashed when it contained TileJson